### PR TITLE
Fix fft example

### DIFF
--- a/test/open_examples/Makefile.linux
+++ b/test/open_examples/Makefile.linux
@@ -2,11 +2,9 @@
 # Makefile for HW Mode on Linux
 ###########################################################################
 
-#macro CM_ROOT and APP_NAME are passed as Make parameters
-#CM_ROOT := /home/gangche1/Perforce/gc-centos-cmrt/SWE_Media_CM_RT/mainline
-#CMC := ../../../build.64.linux/bin/cmc
-CM_ROOT := ../..
-CMC := $(CM_ROOT)/compiler/bin/cmc
+#Variables CM_ROOT and CMC may be set by the user.
+CM_ROOT ?= ../..
+CMC ?= $(CM_ROOT)/compiler/bin/cmc
 APP_NAME_NO_STRIP:= $(shell pwd | awk -F '/' '{print $$NF}' )
 APP_NAME := $(strip $(APP_NAME_NO_STRIP))
 

--- a/test/open_examples/fft/fft_genx.cpp
+++ b/test/open_examples/fft/fft_genx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2017-2019, Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -168,7 +168,7 @@ inline void fftbase_io(SurfaceIndex buf, unsigned width, vector<T, (1 << E) / 4 
     Offset.select<8, 1>() = Offset8;
     #pragma unroll
     for (int i = 8; i < SIMD; i+= 8) {
-        Offset.select<8, 1>(i) += 8;
+        Offset.select<8, 1>(i) = Offset8 + i;
     }
 
     // Read data to compute DFT.


### PR DESCRIPTION
I updated the makefile to allow the user to override CM_ROOT and CMC and removed comments containing Intel usernames.
I updated the fft example to check results without requiring MKL and discovered that the example is broken when SIMD=16.
I fixed fft_genx.cpp.

paul.caprioli@intel.com