### PR TITLE
Add patch for OS SPIRV-Translator to make FE work with it

### DIFF
--- a/cmfe/patches/Add-DecorationFuncParamKindINTEL-and-DecorationFuncP.patch
+++ b/cmfe/patches/Add-DecorationFuncParamKindINTEL-and-DecorationFuncP.patch
@@ -1,0 +1,197 @@
+From 14b58677d2838891a5947f2bfe7007b6c7a6e612 Mon Sep 17 00:00:00 2001
+From: nrudenko <nikita.rudenko@intel.com>
+Date: Wed, 8 Jul 2020 13:25:39 +0300
+Subject: [PATCH 3/4] Add DecorationFuncParamKindINTEL and
+ DecorationFuncParamDescINTEL
+
+Change-Id: I9fd30f9107718d18d789c04e1eca12049267ee30
+---
+ lib/SPIRV/SPIRVReader.cpp             | 12 ++++++++++++
+ lib/SPIRV/SPIRVWriter.cpp             | 13 +++++++++++++
+ lib/SPIRV/VectorComputeUtil.h         |  2 ++
+ lib/SPIRV/libSPIRV/SPIRVDecorate.cpp  | 12 ++++++++++++
+ lib/SPIRV/libSPIRV/SPIRVDecorate.h    |  9 +++++++++
+ lib/SPIRV/libSPIRV/SPIRVEnum.h        |  2 ++
+ lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h |  2 ++
+ lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h |  2 ++
+ lib/SPIRV/libSPIRV/spirv.hpp          |  2 ++
+ 9 files changed, 56 insertions(+)
+
+diff --git a/lib/SPIRV/SPIRVReader.cpp b/lib/SPIRV/SPIRVReader.cpp
+index 3bbe8d0..4dd050a 100644
+--- a/lib/SPIRV/SPIRVReader.cpp
++++ b/lib/SPIRV/SPIRVReader.cpp
+@@ -2645,6 +2645,18 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
+                                       std::to_string(Kind));
+       F->addAttribute(ArgNo + 1, Attr);
+     }
++    if (BA->hasDecorate(DecorationFuncParamKindINTEL, 0, &Kind)) {
++      Attribute Attr = Attribute::get(*Context, kVCMetadata::VCArgumentKind,
++                                      std::to_string(Kind));
++      F->addAttribute(ArgNo + 1, Attr);
++    }
++    if (BA->hasDecorate(DecorationFuncParamDescINTEL)) {
++      auto Desc =
++          BA->getDecorationStringLiteral(DecorationFuncParamDescINTEL);
++      Attribute Attr =
++          Attribute::get(*Context, kVCMetadata::VCArgumentDesc, Desc);
++      F->addAttribute(ArgNo + 1, Attr);
++    }
+   }
+ 
+   // Do not add float control if there is no any
+diff --git a/lib/SPIRV/SPIRVWriter.cpp b/lib/SPIRV/SPIRVWriter.cpp
+index c5c9a6a..499e5cf 100644
+--- a/lib/SPIRV/SPIRVWriter.cpp
++++ b/lib/SPIRV/SPIRVWriter.cpp
+@@ -548,6 +548,19 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
+           .getAsInteger(0, Kind);
+       BA->addDecorate(DecorationFuncParamIOKind, Kind);
+     }
++    if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCArgumentKind)) {
++      SPIRVWord Kind;
++      Attrs.getAttribute(ArgNo + 1, kVCMetadata::VCArgumentKind)
++          .getValueAsString()
++          .getAsInteger(0, Kind);
++      BA->addDecorate(DecorationFuncParamKindINTEL, Kind);
++    }
++    if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCArgumentDesc)) {
++      StringRef Desc =
++          Attrs.getAttribute(ArgNo + 1, kVCMetadata::VCArgumentDesc)
++              .getValueAsString();
++      BA->addDecorate(new SPIRVDecorateFuncParamDescAttr(BA, Desc.str()));
++    }
+   }
+ }
+ 
+diff --git a/lib/SPIRV/VectorComputeUtil.h b/lib/SPIRV/VectorComputeUtil.h
+index 39255ad..772d682 100755
+--- a/lib/SPIRV/VectorComputeUtil.h
++++ b/lib/SPIRV/VectorComputeUtil.h
+@@ -117,6 +117,8 @@ const static char VCGlobalVariable[] = "VCGlobalVariable";
+ const static char VCVolatile[] = "VCVolatile";
+ const static char VCByteOffset[] = "VCByteOffset";
+ const static char VCSIMTCall[] = "VCSIMTCall";
++const static char VCArgumentKind[] = "VCArgumentKind";
++const static char VCArgumentDesc[] = "VCArgumentDesc";
+ } // namespace kVCMetadata
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+diff --git a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+index c160aa3..3b951aa 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
++++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+@@ -94,6 +94,9 @@ void SPIRVDecorate::encode(spv_ostream &O) const {
+   case DecorationUserSemantic:
+     SPIRVDecorateUserSemanticAttr::encodeLiterals(Encoder, Literals);
+     break;
++  case DecorationFuncParamDescINTEL:
++    SPIRVDecorateFuncParamDescAttr::encodeLiterals(Encoder, Literals);
++    break;
+   default:
+     Encoder << Literals;
+   }
+@@ -114,6 +117,9 @@ void SPIRVDecorate::decode(std::istream &I) {
+   case DecorationUserSemantic:
+     SPIRVDecorateUserSemanticAttr::decodeLiterals(Decoder, Literals);
+     break;
++  case DecorationFuncParamDescINTEL:
++    SPIRVDecorateFuncParamDescAttr::decodeLiterals(Decoder, Literals);
++    break;
+   default:
+     Decoder >> Literals;
+   }
+@@ -127,6 +133,9 @@ void SPIRVMemberDecorate::encode(spv_ostream &O) const {
+   case DecorationUserSemantic:
+     SPIRVDecorateUserSemanticAttr::encodeLiterals(Encoder, Literals);
+     break;
++  case DecorationFuncParamDescINTEL:
++    SPIRVDecorateFuncParamDescAttr::encodeLiterals(Encoder, Literals);
++    break;
+   default:
+     Encoder << Literals;
+   }
+@@ -144,6 +153,9 @@ void SPIRVMemberDecorate::decode(std::istream &I) {
+   case DecorationUserSemantic:
+     SPIRVDecorateUserSemanticAttr::decodeLiterals(Decoder, Literals);
+     break;
++  case DecorationFuncParamDescINTEL:
++    SPIRVDecorateFuncParamDescAttr::decodeLiterals(Decoder, Literals);
++    break;
+   default:
+     Decoder >> Literals;
+   }
+diff --git a/lib/SPIRV/libSPIRV/SPIRVDecorate.h b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+index 4a31061..e0d225e 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
++++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+@@ -390,6 +390,15 @@ public:
+                                        AnnotateString) {}
+ };
+ 
++class SPIRVDecorateFuncParamDescAttr
++    : public SPIRVDecorateStrAttrBase<DecorationFuncParamDescINTEL> {
++public:
++  //  Complete constructor for UserSemantic decoration
++  SPIRVDecorateFuncParamDescAttr(SPIRVEntry *TheTarget,
++                                 const std::string &AnnotateString)
++      : SPIRVDecorateStrAttrBase(TheTarget, AnnotateString) {}
++};
++
+ } // namespace SPIRV
+ 
+ #endif // SPIRV_LIBSPIRV_SPIRVDECORATE_H
+diff --git a/lib/SPIRV/libSPIRV/SPIRVEnum.h b/lib/SPIRV/libSPIRV/SPIRVEnum.h
+index 3631188..6731dea 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
++++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
+@@ -384,6 +384,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
+   ADD_VEC_INIT(DecorationFuncParamIOKind, {CapabilityVectorComputeINTEL});
+   ADD_VEC_INIT(DecorationStackCallINTEL, {CapabilityVectorComputeINTEL});
+   ADD_VEC_INIT(DecorationSIMTCallINTEL, {CapabilityVectorComputeINTEL});
++  ADD_VEC_INIT(DecorationFuncParamKindINTEL, {CapabilityVectorComputeINTEL});
++  ADD_VEC_INIT(DecorationFuncParamDescINTEL, {CapabilityVectorComputeINTEL});
+ }
+ 
+ template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {
+diff --git a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+index 45931d2..9b663bf 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
++++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+@@ -410,6 +410,8 @@ inline bool isValid(spv::Decoration V) {
+   case DecorationUserSemantic:
+   case DecorationVectorComputeFunctionINTEL:
+   case DecorationStackCallINTEL:
++  case DecorationFuncParamKindINTEL:
++  case DecorationFuncParamDescINTEL:
+   case DecorationVectorComputeVariableINTEL:
+   case DecorationGlobalVariableOffsetINTEL:
+   case DecorationFuncParamIOKind:
+diff --git a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+index dff28a3..4d9090d 100644
+--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
++++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+@@ -346,6 +346,8 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
+   add(DecorationUserSemantic, "UserSemantic");
+   add(DecorationVectorComputeFunctionINTEL, "VectorComputeFunctionINTEL");
+   add(DecorationStackCallINTEL, "StackCallINTEL");
++  add(DecorationFuncParamKindINTEL, "FuncParamKindINTEL");
++  add(DecorationFuncParamDescINTEL, "FuncParamDescINTEL");
+   add(DecorationVectorComputeVariableINTEL, "VectorComputeVariableINTEL");
+   add(DecorationGlobalVariableOffsetINTEL, "GlobalVariableOffsetINTEL");
+   add(DecorationFuncParamIOKind, "FuncParamIOKind");
+diff --git a/lib/SPIRV/libSPIRV/spirv.hpp b/lib/SPIRV/libSPIRV/spirv.hpp
+index f5ac253..751a679 100644
+--- a/lib/SPIRV/libSPIRV/spirv.hpp
++++ b/lib/SPIRV/libSPIRV/spirv.hpp
+@@ -450,6 +450,8 @@ enum Decoration {
+   DecorationStackCallINTEL = 5627,
+   DecorationGlobalVariableOffsetINTEL = 5628,
+   DecorationUserSemantic = 5635,
++  DecorationFuncParamKindINTEL = 9624,
++  DecorationFuncParamDescINTEL = 9625,
+   DecorationMax = 0x7fffffff,
+ };
+ 
+-- 
+2.21.0


### PR DESCRIPTION
Now SPIRV translator require non-upstreamed patch to work with our FE, adding it as patch here to be picked up by build system