### PR TITLE
Remove repo path from --version output

### DIFF
--- a/cmfe/lib/Basic/Version.cpp
+++ b/cmfe/lib/Basic/Version.cpp
@@ -103,11 +103,7 @@ std::string getClangFullRepositoryVersion() {
   std::string Revision = getClangRevision();
   if (!Path.empty() || !Revision.empty()) {
     OS << "(Clang sources: ";
-    if (!Path.empty())
-      OS << Path;
     if (!Revision.empty()) {
-      if (!Path.empty())
-        OS << ' ';
       OS << Revision;
     }
     OS << ')';
@@ -116,18 +112,12 @@ std::string getClangFullRepositoryVersion() {
   std::string LLVMRev = getLLVMRevision();
   if (!LLVMRev.empty() && LLVMRev != Revision) {
     OS << "(LLVM sources: ";
-    std::string LLVMRepo = getLLVMRepositoryPath();
-    if (!LLVMRepo.empty())
-      OS << LLVMRepo << ' ';
     OS << LLVMRev << ')';
   }
 
   std::string VCIRev = getVCIntrinsicsRevision();
   if (!VCIRev.empty()) {
     OS << "(VC-Intrinsics sources: ";
-    std::string VCIRepo = getVCIntrinsicsRepositoryPath();
-    if (!VCIRepo.empty())
-      OS << VCIRepo << ' ';
     OS << VCIRev << ')';
   }
 


### PR DESCRIPTION
Exposing source repository path may cause IP leak