### PR TITLE
Fix gcc-13 build for make check

### DIFF
--- a/llvm/include/llvm/Support/Base64.h
+++ b/llvm/include/llvm/Support/Base64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_BASE64_H
 #define LLVM_SUPPORT_BASE64_H
 
+#include <cstdint>
 #include <string>
 
 namespace llvm {


### PR DESCRIPTION
Running 'make check' on gcc-13 currently fails to build due to a missing header. This fixes that issue